### PR TITLE
:pencil: Installation alternatives for HIE extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@
 
 - Clone the [`haskell-ide-engine` repo](https://github.com/haskell/haskell-ide-engine) somewhere and install it for GHC 8.6.5:
   - `git clone https://github.com/haskell/haskell-ide-engine && cd haskell-ide-engine`
-  - `./cabal-hie-install hie-8.6.5`
-  - `./cabal-hie-install data`
+  - `./cabal-hie-install hie-8.6.5 or stack ./install.hs hie-8.6.5`
+  - `./cabal-hie-install data or stack ./install.hs data`
 - Install the [VSCode HIE server extension](https://marketplace.visualstudio.com/items?itemName=alanz.vscode-hie-server) for Visual Studio Code.
 - Install the [VSCode ormolu extension](https://marketplace.visualstudio.com/items?itemName=sjurmillidahl.ormolu-vscode) and set it as the default formatter.
 


### PR DESCRIPTION
:pencil: Add two alternatives when installing hie extension and its data in case the first way fail

I've been having problems installing the hie extension in my Windows 10 laptop using:

```
  - `./cabal-hie-install hie-8.6.5`
  - `./cabal-hie-install data`
```

By following the instructions at [this repository](https://github.com/haskell/haskell-ide-engine#windows-specific-pre-requirements), I've been able to install it correctly, may be useful for the next one that has the same problem as I did